### PR TITLE
Fix code scanning alert no. 1: Jinja2 templating with autoescape=False

### DIFF
--- a/scripts/docs.py
+++ b/scripts/docs.py
@@ -14,7 +14,7 @@ import mkdocs.config
 import mkdocs.utils
 import cligenius
 import yaml
-from jinja2 import Template
+from jinja2 import Environment, select_autoescape
 
 app = cligenius.Cligenius()
 
@@ -236,7 +236,8 @@ def generate_readme_content():
         raise RuntimeError("Couldn't auto-generate sponsors section")
     pre_end = match_start.end()
     post_start = match_end.start()
-    template = Template(index_sponsors_template)
+    env = Environment(autoescape=select_autoescape(['html', 'xml']))
+    template = env.from_string(index_sponsors_template)
     message = template.render(sponsors=sponsors)
     pre_content = content[:pre_end]
     post_content = content[post_start:]


### PR DESCRIPTION
Fixes [https://github.com/khulnasoft/github-actions-sandbox/security/code-scanning/1](https://github.com/khulnasoft/github-actions-sandbox/security/code-scanning/1)

To fix the problem, we need to ensure that `autoescape` is enabled when creating the `Template` object. The best way to do this is to use the `Environment` class from `jinja2` with `autoescape` set to `select_autoescape(['html', 'xml'])`. This will automatically enable escaping for HTML and XML templates, which is appropriate for the given context.

We will modify the code to create an `Environment` object with `autoescape` enabled and use this environment to get the template.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
